### PR TITLE
update: add sanity check for wasm binary

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -100,6 +100,10 @@ func (d *Dialer) dialWATER(network, remoteAddr string,
 		NetworkDialerFunc:  dialerFunc,
 	}
 
+	if len(config.TransportModuleBin) == 0 {
+		return nil, errors.New("water: WebAssembly Transport Module binary is not provided in config")
+	}
+
 	if d.configJSON != nil {
 		config.UnmarshalJSON(d.configJSON)
 	} else if d.configPB != nil {


### PR DESCRIPTION
`(*water.Config).WATMBinOrPanic()` will cause Android app to crash. 

Maybe it is not a good idea to enforce the panic in such library functions. 