### PR TITLE
:arrow_down: deps: use Android 8.1 (API 27)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IOS_ARTIFACT=$(BUILDDIR)/WaterMob.framework
 ANDROID_ARTIFACT=$(BUILDDIR)/watermob.aar
 IOS_TARGET=ios
 ANDROID_TARGET=android
-ANDROID_API=28
+ANDROID_API=27
 # LDFLAGS='-s -w -X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn'
 LDFLAGS='-s -w'
 IMPORT_PATH=github.com/gaukas/watermob


### PR DESCRIPTION
Downgrade to Android 8.1 for better test coverage. 